### PR TITLE
feat: move migrations test modules to run against different emulator …

### DIFF
--- a/.github/workflows/django_tests_against_emulator2.yml
+++ b/.github/workflows/django_tests_against_emulator2.yml
@@ -29,4 +29,4 @@ jobs:
           GOOGLE_CLOUD_TESTS_CREATE_SPANNER_INSTANCE: true
           RUNNING_SPANNER_BACKEND_TESTS: 1
           SPANNER_TEST_INSTANCE: google-cloud-django-backend-tests
-          DJANGO_TEST_APPS: migration_test_data_persistence max_lengths migrate_signals migrations select_for_update queries
+          DJANGO_TEST_APPS: migration_test_data_persistence max_lengths migrate_signals select_for_update queries

--- a/.github/workflows/django_tests_against_emulator4.yml
+++ b/.github/workflows/django_tests_against_emulator4.yml
@@ -29,4 +29,4 @@ jobs:
           GOOGLE_CLOUD_TESTS_CREATE_SPANNER_INSTANCE: true
           RUNNING_SPANNER_BACKEND_TESTS: 1
           SPANNER_TEST_INSTANCE: google-cloud-django-backend-tests
-          DJANGO_TEST_APPS: admin_inlines admin_ordering aggregation
+          DJANGO_TEST_APPS: admin_inlines admin_ordering aggregation migrations


### PR DESCRIPTION
…(#613)

* fix: lint_setup_py was failing in Kokoro is not fixed

* feat: move migrations and queries test modules to run against different emmulators to distribute time taken by emmulator 2